### PR TITLE
Develop

### DIFF
--- a/usr/lib/enigma2/python/Plugins/Extensions/vavoo/Console.py
+++ b/usr/lib/enigma2/python/Plugins/Extensions/vavoo/Console.py
@@ -12,10 +12,7 @@ from Components.ActionMap import ActionMap
 from Screens.MessageBox import MessageBox
 from enigma import getDesktop
 
-from . import PY3
-
-import gettext
-_ = gettext.gettext
+from . import PY3, _
 
 
 def getDesktopSize():

--- a/usr/lib/enigma2/python/Plugins/Extensions/vavoo/bouquet_manager.py
+++ b/usr/lib/enigma2/python/Plugins/Extensions/vavoo/bouquet_manager.py
@@ -39,7 +39,6 @@ from . import (
     PLUGIN_ROOT,
     PROXY_HOST,
     ENIGMA_PATH,
-    country_codes
 )
 
 """
@@ -291,13 +290,7 @@ def convert_bouquet_sync(
             return 0
 
         # 4. Extract country code
-        separators = ["➾", "⟾", "->", "→"]
-        base_name = name
-        for sep in separators:
-            if sep in name:
-                base_name = name.split(sep)[0].strip()
-                break
-        country_code = country_codes.get(base_name.capitalize(), "")
+        country_code = get_country_code_from_bouquet_name(name) or ""
 
         # 5. Get matcher
         matcher = get_epg_matcher()
@@ -666,6 +659,11 @@ def process_epg_matching_background(
                 print(
                     "[EPGBackground] Updated %d service lines in %s" %
                     (changes, bouquet_filename))
+                # Without this, Enigma2's live service database keeps
+                # using the fallback refs written in phase 1 until a
+                # manual reload/reboot, so the just-matched EPG never
+                # actually shows up despite the "completed" notification.
+                reactor.callFromThread(ReloadBouquets)
 
         # 5. Generate EPG mapping files
         if matched:
@@ -880,15 +878,10 @@ def create_fallback_bouquet_sync(
             return 0, "", [], ""
 
         # 4. Extract country code for later EPG
-        separators = ["➾", "⟾", "->", "→"]
-        base_name = name
-        for sep in separators:
-            if sep in name:
-                base_name = name.split(sep)[0].strip()
-                break
-        country_code = country_codes.get(base_name.capitalize(), "")
+        country_code = get_country_code_from_bouquet_name(name) or ""
 
         # 5. Prepare bouquet filename (same logic as create_bouquet_file)
+        separators = ["➾", "⟾", "->", "→"]
         is_category = any(sep in name for sep in separators)
         if export_type == "flat" or not is_category:
             safe_name = name.lower().replace(

--- a/usr/lib/enigma2/python/Plugins/Extensions/vavoo/channel_alias.py
+++ b/usr/lib/enigma2/python/Plugins/Extensions/vavoo/channel_alias.py
@@ -348,9 +348,15 @@ def normalize_channel_name(raw_name):
     from re import sub, IGNORECASE
     # First, strip any trailing quality markers and clean up
     name = raw_name.upper().strip()
-    # Remove common suffixes like .c, .s, HD, FHD, etc.
-    name = sub(r'\s*\.(c|s)$', '', name)
-    name = sub(r'\s*(HD|FHD|SD|4K|HEVC|H265)$', '', name, flags=IGNORECASE)
+    # Remove common suffixes like .c, .s, HD, FHD, etc. name is already
+    # uppercased above, so these need IGNORECASE to actually match.
+    # 4K is deliberately NOT stripped here: unlike HD/FHD/SD/HEVC/H265
+    # (pure quality tags that collapse onto the same base channel),
+    # "RAI 4K" and "SKY SPORT 4K" are their own distinct channels with
+    # dedicated ALIAS_MAP entries - stripping it would silently merge
+    # them into the wrong (non-4K) channel.
+    name = sub(r'\s*\.(c|s)$', '', name, flags=IGNORECASE)
+    name = sub(r'\s*(HD|FHD|SD|HEVC|H265)$', '', name, flags=IGNORECASE)
     # Apply explicit rename rules. Exact match, not substring: several
     # patterns are single digits or short generic words ("8", "27",
     # "RAI", "SUPER") meant to disambiguate a channel literally named

--- a/usr/lib/enigma2/python/Plugins/Extensions/vavoo/plugin.py
+++ b/usr/lib/enigma2/python/Plugins/Extensions/vavoo/plugin.py
@@ -530,66 +530,6 @@ except BaseException:
     pass
 
 
-# check server
-def raises(url):
-    """Attempts to fetch a URL with retries and error handling"""
-    try:
-        if requests is not None:
-            http = requests.Session()
-            if HTTPAdapter is not None:
-                if Retry is not None:
-                    retries = Retry(total=1, backoff_factor=1)
-                    adapter = HTTPAdapter(max_retries=retries)
-                else:
-                    adapter = HTTPAdapter(max_retries=1)
-                http.mount("http://", adapter)
-                http.mount("https://", adapter)
-
-            r = http.get(
-                url,
-                headers={'User-Agent': vUtils.RequestAgent()},
-                timeout=(3, 10),
-                verify=True,
-                stream=True,
-                allow_redirects=False
-            )
-            r.raise_for_status()
-
-            if r.status_code == requests.codes.ok:
-                for xc in r.iter_content(1024):
-                    pass
-                r.close()
-                return True
-        else:
-            req = UrlRequest(
-                url, headers={
-                    'User-Agent': vUtils.RequestAgent()})
-            resp = urlopen(req, timeout=10)
-            status_code = getattr(resp, 'getcode', lambda: 0)() or 0
-            if status_code == 200:
-                return True
-
-    except Exception as e:
-        print("Server check failed:", e)
-    return False
-
-
-def zServer(opt=0, server=None, port=None):
-    """Checks if a server is reachable and returns it, fallback to default"""
-    try:
-        from urllib.error import HTTPError
-    except ImportError:
-        from urllib2 import HTTPError
-
-    try:
-        if raises(server):
-            print('server is reachable:', str(server))
-            return str(server)
-    except HTTPError as err:
-        print(err.code)
-        return PRIMARY_BASE_URL
-
-
 # menulist
 class m2list(MenuList):
     def __init__(self, items):
@@ -1944,6 +1884,16 @@ class MainVavoo(Screen):
             print("[DEBUG] fix_cache_format cancelled by user")
             return
 
+        # An in-progress export's EPG-matching phase writes the same
+        # cache file (see bouquet_manager.process_epg_matching_background)
+        # with no lock of its own - share export_lock so the two can't
+        # interleave and corrupt/clobber each other's write.
+        if not export_lock.acquire(blocking=False):
+            if NOTIFICATION_AVAILABLE:
+                quick_notify(
+                    _("An export is in progress. Please wait before fixing the cache."), 4)
+            return
+
         try:
             if NOTIFICATION_AVAILABLE:
                 quick_notify(_("Fixing cache format..."), 2)
@@ -1984,6 +1934,8 @@ class MainVavoo(Screen):
                 MessageBox.TYPE_ERROR,
                 timeout=5
             )
+        finally:
+            export_lock.release()
 
     def reload_bouquets_with_popup(self):
         """Reload bouquets with confirmation popup"""
@@ -3085,64 +3037,6 @@ class vavoo(Screen):
             self.timer.timeout.connect(self.cat)
         self.timer.start(500, True)
 
-    def _initialize_proxy_for_country(self):
-        """Initialize the proxy for the selected country"""
-        try:
-            print("[vavoo] Initializing proxy for country: " +
-                  str(self.country_name))
-
-            # URL to initialize the proxy for the specific country
-            init_url = PROXY_BASE_URL + \
-                "/initialize_country?country={}".format(self.country_name)
-            content = getUrl(init_url, timeout=10)
-            if content:
-                if PY3:
-                    content = ensure_str(content)
-
-                result = loads(content)
-                if result.get("status") == "ok":
-                    print("[vavoo] Proxy initialized for " +
-                          str(self.country_name))
-                    self.proxy_initialized = True
-                    return True
-
-        except Exception as e:
-            print("[vavoo] Proxy initialization error: " + str(e))
-
-        return False
-
-    def debug_proxy_state(self):
-        """Debug function to check proxy state"""
-        try:
-            print("=" * 60)
-            print(
-                "[DEBUG] Checking proxy state for country: " +
-                self.country_name)
-
-            # 1. Check status
-            status_url = PROXY_STATUS_URL
-            status = getUrl(status_url, timeout=3)
-            if status:
-                print("[DEBUG] Proxy Status: " + status[:200])
-
-            # 2. Check countries list
-            countries_url = PROXY_COUNTRIES_URL
-            countries = getUrl(countries_url, timeout=3)
-            if countries:
-                print("[DEBUG] Available countries: " + countries[:200])
-
-            # 3. Try to get channels
-            test_url = PROXY_BASE_URL + "/channels?country=Italy"
-            channels = getUrl(test_url, timeout=5)
-            print("[DEBUG] Channels response length: " +
-                  str(len(channels) if channels else 0))
-            if channels and len(channels) < 500:
-                print("[DEBUG] Channels data: " + channels)
-
-            print("=" * 60)
-        except Exception as e:
-            print("[DEBUG] Error checking proxy: " + str(e))
-
     def cat(self):
         """Load channels for the selected country with proxy verification and fallback"""
         print("[DEBUG] vavoo.cat() called for country: " + str(self.country_name))
@@ -3282,28 +3176,6 @@ class vavoo(Screen):
         except Exception:
             pass
 
-    def _ensure_proxy_ready(self, timeout=10):
-        """Ensures the proxy is ready"""
-        for i in range(timeout):
-            if is_proxy_ready(timeout=2):
-                return True
-
-            if i == 0:
-                self['name'].setText(_("Waiting for proxy..."))
-
-            select.select([], [], [], 1)
-
-        self.session.open(
-            MessageBox,
-            _("Proxy not responding after") +
-            " " +
-            str(timeout) +
-            " " +
-            _("seconds"),
-            MessageBox.TYPE_ERROR,
-            timeout=5)
-        return False
-
     def _update_proxy_status_display(self):
         """Internal method to update proxy status display"""
         try:
@@ -3344,166 +3216,6 @@ class vavoo(Screen):
         except Exception as e:
             print("[MainVavoo] Error updating proxy status: " + str(e))
             self['proxy_status'].setText(_("✗ Error"))
-
-    def _check_and_ensure_proxy_ready(self):
-        """Check proxy status and try to fix issues if needed"""
-        status = {
-            "ready": False,
-            "message": "",
-            "needs_restart": False,
-            "needs_start": False,
-        }
-
-        if not cfg.proxy_enabled.value:
-            status["message"] = "Proxy disabled"
-            status["needs_start"] = True
-            return status
-
-        if not is_proxy_running():
-            status["message"] = "Proxy not running"
-            status["needs_restart"] = True
-            return status
-
-        try:
-            proxy_response = getUrl(PROXY_STATUS_URL, timeout=3)
-            if not proxy_response:
-                status["message"] = "Cannot get proxy status"
-                status["needs_restart"] = True
-                return status
-
-            proxy_data = loads(proxy_response)
-
-            if not proxy_data.get("initialized", False):
-                status["message"] = "Proxy not initialized"
-                status["needs_restart"] = True
-                return status
-
-            if not proxy_data.get("addon_sig_valid", False):
-                status["message"] = "Token not valid"
-                status["needs_restart"] = True
-                return status
-
-            token_age = proxy_data.get("addon_sig_age", 0)
-            if token_age > 420:
-                print(
-                    "[vavoo] Token old (" +
-                    str(token_age) +
-                    "s), forcing refresh...")
-                try:
-                    getUrl(PROXY_REFRESH_URL, timeout=3)
-                except Exception:
-                    pass
-
-            status["ready"] = True
-            status["message"] = "Proxy ready"
-            return status
-
-        except Exception as e:
-            status["message"] = "Error checking proxy: " + str(e)
-            status["needs_restart"] = True
-            return status
-
-    def _try_proxy_recovery(self):
-        """Attempt to recover proxy connection asynchronously."""
-        if not cfg.proxy_enabled.value:
-            return False
-
-        print("[vavoo] Attempting proxy recovery...")
-
-        # 1. Try token refresh in a background thread (getUrl is blocking)
-        def do_refresh():
-            try:
-                getUrl(PROXY_REFRESH_URL, timeout=3)
-            except Exception:
-                pass
-        threading.Thread(target=do_refresh, daemon=True).start()
-
-        # 2. If proxy is not ready, schedule a restart
-        if not is_proxy_ready(timeout=1):
-            reactor.callLater(1, self._restart_proxy_and_reload)
-        return False
-
-    def _restart_proxy_and_reload(self):
-        timeout = cfg.proxy_startup_timeout.value
-        run_proxy_in_background(startup_timeout=timeout)
-        # Reload channel list after 3 seconds (enough for proxy to start)
-        reactor.callLater(3, self.cat)
-
-    def _show_proxy_error(self, status):
-        """Show proxy error message"""
-        error_msg = _("Proxy Error: ") + status["message"]
-        print("[vavoo] " + error_msg)
-        self['name'].setText(error_msg)
-
-        # Offer restart option
-        if status["needs_restart"]:
-            self.session.openWithCallback(
-                self._restart_proxy_callback,
-                MessageBox,
-                "Proxy needs restart: " + status["message"] + "\nRestart now?",
-                MessageBox.TYPE_YESNO
-            )
-
-    def _restart_proxy_callback(self, result):
-        """Callback for proxy restart"""
-        if result:
-            print("[vavoo] User requested proxy restart")
-            timeout = cfg.proxy_startup_timeout.value
-            run_proxy_in_background(startup_timeout=timeout)
-            # Wait and retry
-            self.session.open(
-                MessageBox,
-                _("Proxy restarting... Please wait"),
-                MessageBox.TYPE_INFO,
-                timeout=3)
-
-            # Retry loading after 3 seconds
-            self.timer = eTimer()
-            try:
-                self.timer.callback.append(self.cat)
-            except Exception:
-                self.timer.timeout.connect(self.cat)
-            self.timer.start(3000, True)
-
-    def start_vavoo_proxy(self):
-        if not cfg.proxy_enabled.value:
-            return False
-        if is_proxy_running():
-            print("[MainVavoo] Proxy already running")
-            return True
-
-        print("[MainVavoo] Starting proxy...")
-        timeout = cfg.proxy_startup_timeout.value
-        success = run_proxy_in_background(startup_timeout=timeout)
-        if success:
-            for i in range(10):
-                if is_proxy_ready(timeout=1):
-                    print("[MainVavoo] Proxy ready")
-                    return True
-                select.select([], [], [], 1)
-            print("[MainVavoo] Proxy started but not ready after 10s")
-        else:
-            print("[MainVavoo] Proxy start error")
-        return False
-
-    def _matches_selection(self, country_field, selected_name):
-        """
-        Check if a channel matches the selection
-        country_field: country field from JSON (ex: "France" or "France ➾ Sports")
-        selected_name: what user selected (ex: "France" or "France ➾ Sports")
-        """
-        country_field = url_unquote(country_field).strip("\r\n")
-        selected_name = selected_name.strip()
-
-        # If user selected main country (without ➾)
-        if "➾" not in selected_name:
-            # Show ALL channels from that country, including subcategories
-            # Match exact country OR country with any subcategory
-            return country_field == selected_name or country_field.startswith(
-                selected_name + " ➾")
-        else:
-            # User selected specific category - exact match only
-            return country_field == selected_name
 
     def _reload_services(self):
         try:
@@ -3658,38 +3370,6 @@ class vavoo(Screen):
                 [name, url],
                 [[[name, url]]]
             )
-
-    def filterM3u(self, result):
-        global search_ok
-        if result:
-            try:
-                self.cat_list = []
-                search_filter = result
-                for item in self.itemlist:
-                    name = item.split('###')[0]
-                    url = item.split('###')[1]
-                    if search_filter.lower() in str(name).lower():
-                        search_ok = True
-                        namex = name
-                        urlx = url.replace('%0a', '').replace('%0A', '')
-                        self.cat_list.append(show_list(namex, urlx))
-                if len(self.cat_list) < 1:
-                    _session.open(
-                        MessageBox,
-                        _('No channels found in search!!!'),
-                        MessageBox.TYPE_INFO,
-                        timeout=5)
-                    return
-                else:
-                    self['menulist'].l.setList(self.cat_list)
-                    # self['menulist'].moveToIndex(0)
-                    txtsream = self['menulist'].getCurrent()[0][0]
-                    self['name'].setText(str(txtsream))
-            except Exception as e:
-                print(e)
-                trace_error()
-                self['name'].setText(_('Error'))
-                search_ok = False
 
     def goConfig(self):
         self.session.open(vavoo_config)

--- a/usr/lib/enigma2/python/Plugins/Extensions/vavoo/plugin.py
+++ b/usr/lib/enigma2/python/Plugins/Extensions/vavoo/plugin.py
@@ -2963,6 +2963,24 @@ class vavoo(Screen):
         self._verify_proxy_ready()
 
         self._initialize_timer()
+        self._initialize_proxy_status_timer()
+
+    def _initialize_proxy_status_timer(self):
+        """Keep the proxy_status label live while this screen is open.
+
+        Unlike MainVavoo (which refreshes every 10s via
+        proxy_monitor_timer), this screen previously only set the label
+        once in _verify_proxy_ready() and never again, so it went stale
+        the moment the user opened a country.
+        """
+        self.proxy_status_timer = eTimer()
+        try:
+            self.proxy_status_timer.timeout.connect(
+                self._update_proxy_status_display)
+        except BaseException:
+            self.proxy_status_timer.callback.append(
+                self._update_proxy_status_display)
+        self.proxy_status_timer.start(10000)
 
     def _verify_proxy_ready(self):
         """Verify that the proxy is ready without attempting to start it"""
@@ -3433,6 +3451,11 @@ class vavoo(Screen):
                 pass
         except Exception as e:
             print("Error stopping timer: " + str(e))
+        try:
+            if hasattr(self, 'proxy_status_timer'):
+                self.proxy_status_timer.stop()
+        except Exception as e:
+            print("Error stopping proxy_status_timer: " + str(e))
         return Screen.close(self, *args, **kwargs)
 
     def backhome(self):

--- a/usr/lib/enigma2/python/Plugins/Extensions/vavoo/update_translations.py
+++ b/usr/lib/enigma2/python/Plugins/Extensions/vavoo/update_translations.py
@@ -510,7 +510,13 @@ def fix_po_file(po_file):
                         i += 1
                     continue
                 else:
+                    # Duplicate header block: skip its msgid/msgstr AND
+                    # all its quoted continuation lines too, or those
+                    # would fall through below as orphaned top-level
+                    # strings attached to no msgid/msgstr (invalid PO).
                     i += 2
+                    while i < len(lines) and lines[i].strip().startswith('"'):
+                        i += 1
                     continue
             if line.strip().startswith('msgid "') and '""' in line:
                 fixed_lines.append('msgid ""\n')

--- a/usr/lib/enigma2/python/Plugins/Extensions/vavoo/vUtils.py
+++ b/usr/lib/enigma2/python/Plugins/Extensions/vavoo/vUtils.py
@@ -1413,7 +1413,14 @@ def get_country_code_from_bouquet_name(name):
         if sep in name:
             base_name = name.split(sep)[0].strip()
             break
-    return country_codes.get(base_name.capitalize(), None)
+    # Case-insensitive lookup: .capitalize() breaks multi-word names
+    # like "United Kingdom" -> "United kingdom", which then can't match
+    # the Title-Case keys in country_codes.
+    base_name_lower = base_name.lower()
+    for key, code in country_codes.items():
+        if key.lower() == base_name_lower:
+            return code
+    return None
 
 
 def get_country_code(country_name):
@@ -1843,7 +1850,7 @@ class VavooEPGMatcher:
             return
 
         try:
-            with open(rytec_file, 'r', encoding='utf-8') as f:
+            with io.open(rytec_file, 'r', encoding='utf-8') as f:
                 content = f.read()
 
             pattern = r'<channel\s+id="([^"]+)">([^<]+)</channel>\s*(?:<!--\s*([^>]+)\s*-->)?'

--- a/usr/lib/enigma2/python/Plugins/Extensions/vavoo/vavoo_proxy.py
+++ b/usr/lib/enigma2/python/Plugins/Extensions/vavoo/vavoo_proxy.py
@@ -714,10 +714,6 @@ class VavooProxy:
         def token_monitor_loop():
             while not self._stop_event.is_set():
                 # Check FIRST, then sleep (first check is immediate at startup)
-                if hasattr(self, 'active_streams') and self.active_streams:
-                    select.select([], [], [], 120)
-                else:
-                    select.select([], [], [], 60)
                 try:
                     now = time.time()
                     token_age = (now - self.addon_sig_data["ts"]

--- a/usr/lib/enigma2/python/Plugins/Extensions/vavoo/vavoo_stats.py
+++ b/usr/lib/enigma2/python/Plugins/Extensions/vavoo/vavoo_stats.py
@@ -57,26 +57,33 @@ class AnonymousStats:
         self._session_id = None
         self._send_timer = None
 
-    def _get_anonymous_session_id(self):
+    def _get_or_create_session_id(self):
+        """Return (session_id, already_sent) for this boot.
+
+        SESSION_ID_FILE lives in /tmp, which is wiped on reboot, so an
+        existing file means we already recorded+sent a startup event
+        earlier in this same boot - reuse that id and skip sending
+        again. Only generate (and later persist) a fresh id when no
+        file exists yet.
+        """
+        if os.path.exists(SESSION_ID_FILE):
+            try:
+                with open(SESSION_ID_FILE, "r") as f:
+                    existing = f.read().strip()
+                if existing:
+                    return existing, True
+            except Exception:
+                pass
         seed = "{}_{}_{}".format(
             time.time(),
             os.getpid(),
             random.randint(
                 1,
                 1000000))
-        return hashlib.md5(seed.encode("utf-8")).hexdigest()[:16]
+        return hashlib.md5(seed.encode("utf-8")).hexdigest()[:16], False
 
     def _is_disabled(self):
         return os.path.exists(STATS_DISABLE_FILE)
-
-    def _should_send_for_session(self):
-        if os.path.exists(SESSION_ID_FILE):
-            try:
-                with open(SESSION_ID_FILE, "r") as f:
-                    return f.read().strip() == self._session_id
-            except Exception:
-                pass
-        return False
 
     def _mark_session_sent(self):
         try:
@@ -94,7 +101,11 @@ class AnonymousStats:
         if self._is_disabled():
             debug("Stats disabled")
             return
-        self._session_id = self._get_anonymous_session_id()
+        self._session_id, already_sent = self._get_or_create_session_id()
+        if already_sent:
+            debug(
+                "Stats already sent for this session: {}".format(self._session_id[:16]))
+            return
         debug(
             "Recording startup - Session ID: {}".format(self._session_id[:16]))
         self._send_in_background()
@@ -104,10 +115,6 @@ class AnonymousStats:
             try:
                 if self._is_disabled():
                     debug("Stats disabled by user")
-                    return
-
-                if self._should_send_for_session():
-                    debug("Stats already sent for this session")
                     return
 
                 payload = {

--- a/usr/lib/enigma2/python/Plugins/Extensions/vavoo/xml2pot.py
+++ b/usr/lib/enigma2/python/Plugins/Extensions/vavoo/xml2pot.py
@@ -60,13 +60,11 @@ def main():
         print("Usage: python xml2pot.py <setup.xml>")
         sys.exit(1)
 
-    # FIXED PATHS
-    xml_file = "setup.xml"  # Same folder as the script
-    pot_file = "locale/Calendar.pot"  # In locale/ folder
+    xml_file = sys.argv[1]
+    pot_file = "locale/vavoo.pot"  # In locale/ folder
 
     if not os.path.exists(xml_file):
         print("File not found: %s" % xml_file)
-        print("Make sure xml2pot.py is in the same folder as setup.xml")
         sys.exit(1)
 
     # Extract strings


### PR DESCRIPTION
- Fixed several EPG/channel-matching bugs: country codes for two-word
  countries (e.g. "United Kingdom") weren't recognized due to a broken
  case-normalization, breaking flags and EPG file handling for those
  countries; "RAI 4K"/"SKY SPORT 4K" lost their alias matching because
  a quality-suffix filter was stripping "4K" as if it were a resolution
  tag; Rytec EPG database failed to load silently on Python 2 images.
- Fixed bouquets not showing correct EPG after export: the background
  EPG-matching step rewrote the bouquet file with real service
  references but never told Enigma2 to reload them, so channels kept
  using the old fallback references until a manual reload/reboot.
- Fixed proxy status not updating after selecting a country - it froze
  at whatever it read when the screen opened instead of refreshing
  every 10s like the main menu does.
- Fixed the Console (installer) screen always showing English text
  regardless of the user's language.
- Fixed anonymous usage stats firing on every plugin open instead of
  once per boot.
- Fixed the proxy's token-refresh monitor checking token age half as
  often as intended (a leftover double sleep).
- Removed a large block of dead code with no remaining callers
  (~330 lines) and guarded the cache-format-fix button against a race
  with an in-progress bouquet export.
- Fixed two translation-tooling bugs (xml2pot.py, update_translations.py)
  that only affected the dev-time translation update scripts, not the
  shipped plugin.